### PR TITLE
Propose DrivingCycles to be included

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -273,6 +273,15 @@
       ["*", "experimental"]
     ]
   },
+  "DrivingCycles": {
+    "names": ["DrivingCacles"],
+    "gitlab": "christiankral/DrivingCycles",
+    "support": [
+      ["prerelease", "noSupport"],
+      [">=0.1.0", "experimental"],
+      ["*", "obsolete"]
+    ]
+  },
   "ElectricalEnergyStorage": {
     "names": ["ElectricalEnergyStorage"],
     "github": "modelica-3rdparty/ElectricalEnergyStorage",


### PR DESCRIPTION
This packages contains public data of driving cycles stored in external files. 