### PR TITLE
Update name of AMIT-HSBI

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -1034,7 +1034,7 @@
   },
   "PNlib": {
     "names": ["PNlib"],
-    "github": "AMIT-FHBielefeld/PNlib",
+    "github": "AMIT-HSBI/PNlib",
     "branches": {"master": "master"},
     "semverTagOverridesAnnotation": true,
     "support": [


### PR DESCRIPTION
`FH Bielefeld - University of Applied Sciences` changed its name to `Hochschule Bielefeld - University of Applied Sciences and Arts` in 2023, see https://www.hsbi.de/presse/pressemitteilungen/aus-fh-wird-hsbi-die-fachhochschule-bielefeld-wird-zur-hochschule-bielefeld

We renamed `AMIT-FHBielefeld` to [AMIT-HSBI](https://github.com/AMIT-HSBI).