### PR TITLE
Adding NeuralNetwork v2.0.0

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -923,9 +923,11 @@
   },
   "NeuralNetwork": {
     "names": ["NeuralNetwork"],
-    "github": "modelica-3rdparty/NeuralNetwork",
+    "github": "AMIT-HSBI/NeuralNetwork",
+    "branches": { "main": "main" },
     "support": [
       ["prerelease", "noSupport"],
+      [">=2.0.0", "experimental"],
       ["*", "obsolete"]
     ]
   },


### PR DESCRIPTION
## Changes

  - Merged old NeuralNetwork v1.0.0 from https://github.com/modelica-3rdparty/NeuralNetwork with repository containing newer developments at https://github.com/AMIT-HSBI/NeuralNetwork.