### PR TITLE
Fix jenkins stage cache

### DIFF
--- a/ompackagemanager/__main__.py
+++ b/ompackagemanager/__main__.py
@@ -1,3 +1,4 @@
+from ompackagemanager import generate_cache
 import argparse
 import warnings
 
@@ -14,8 +15,6 @@ except ImportError as e:
     check_missing = None
     check_uses = None
     warnings.warn("Failed to load some modules!\n%s" % str(e))
-
-from ompackagemanager import generate_cache
 
 
 def main(argv=None):

--- a/ompackagemanager/__main__.py
+++ b/ompackagemanager/__main__.py
@@ -1,10 +1,21 @@
 import argparse
+import warnings
 
-from ompackagemanager import updateinfo
-from ompackagemanager import genindex
+importError = False
+try:
+    from ompackagemanager import updateinfo
+    from ompackagemanager import genindex
+    from ompackagemanager import check_missing
+    from ompackagemanager import check_uses
+except ImportError as e:
+    importError = True
+    updateinfo = None
+    genindex = None
+    check_missing = None
+    check_uses = None
+    warnings.warn("Failed to load some modules!\n%s" % str(e))
+
 from ompackagemanager import generate_cache
-from ompackagemanager import check_missing
-from ompackagemanager import check_uses
 
 
 def main(argv=None):
@@ -15,12 +26,14 @@ def main(argv=None):
     # updateinfo command
     parser1 = subparsers.add_parser(
         'updateinfo', help='Generate up-to-date `rawdata.json`.')
-    parser1.set_defaults(func=updateinfo.main)
+    if not importError:
+        parser1.set_defaults(func=updateinfo.main)
 
     # genindex command
     parser2 = subparsers.add_parser(
         'genindex', help='Generate `index.json` from `rawdata.json`.')
-    parser2.set_defaults(func=genindex.main)
+    if not importError:
+        parser2.set_defaults(func=genindex.main)
 
     # generate-cache command
     parser3 = subparsers.add_parser(
@@ -34,11 +47,13 @@ def main(argv=None):
     parser4 = subparsers.add_parser(
         'check-missing',
         help='Print all GitHub repositories missing from modelica-3rdparty for packages from `repos.json`.')
-    parser4.set_defaults(func=check_missing.main)
+    if not importError:
+        parser4.set_defaults(func=check_missing.main)
 
     # check-uses
     parser5 = subparsers.add_parser('check-uses', help='Some help')
-    parser5.set_defaults(func=check_uses.main)
+    if not importError:
+        parser5.set_defaults(func=check_uses.main)
 
     args = parser.parse_args(argv)
     print(args.script)

--- a/ompackagemanager/updateinfo.py
+++ b/ompackagemanager/updateinfo.py
@@ -1,4 +1,3 @@
-import OMPython
 import os
 from github import Github
 from atlassian import Bitbucket
@@ -8,7 +7,15 @@ import glob
 import re
 import shutil
 import requests
+import warnings
 import zipfile
+
+try:
+    import OMPython
+except ImportError:
+    OMPython = None
+    warnings.warn("Failed to load module OMPython.")
+
 
 from ompackagemanager import common
 
@@ -63,6 +70,9 @@ def main():
     """
     gh_auth = os.environ["GITHUB_AUTH"]
     g = Github(gh_auth)
+
+    if OMPython is None:
+        raise Exception("Module OMPython missing, aborting!")
 
     omc = OMPython.OMCSessionZMQ()
 

--- a/ompackagemanager/updateinfo.py
+++ b/ompackagemanager/updateinfo.py
@@ -1,21 +1,14 @@
+import glob
+import json
+import OMPython
 import os
+import pygit2
+import re
+import requests
+import shutil
+import zipfile
 from github import Github
 from atlassian import Bitbucket
-import json
-import pygit2
-import glob
-import re
-import shutil
-import requests
-import warnings
-import zipfile
-
-try:
-    import OMPython
-except ImportError:
-    OMPython = None
-    warnings.warn("Failed to load module OMPython.")
-
 
 from ompackagemanager import common
 
@@ -70,9 +63,6 @@ def main():
     """
     gh_auth = os.environ["GITHUB_AUTH"]
     g = Github(gh_auth)
-
-    if OMPython is None:
-        raise Exception("Module OMPython missing, aborting!")
 
     omc = OMPython.OMCSessionZMQ()
 


### PR DESCRIPTION
## Issue

Fixes bug introduced in https://github.com/OpenModelica/OMPackageManager/pull/46

https://test.openmodelica.org/jenkins/blue/organizations/jenkins/Update%20Package%20Index/detail/Update%20Package%20Index/8069/pipeline

#48 wasn't enough.

## Changes

  - `python -m ompackagemanager generate-cache` can be used without module OMPython