### PR TITLE
Don't override semver prerelease for master/main/trunk

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,18 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.13']
+        omc-version: ['stable']
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: "Set up OpenModelica Compiler"
+        uses: OpenModelica/setup-openmodelica@v1.0
+        with:
+          version: ${{ matrix.omc-version }}
+          packages: |
+            omc
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ __pycache__
 *.pyc
 /.venv/
 /.vscode/
-cache
+/cache/
 index.json
+tests/tmp-cache/

--- a/ompackagemanager/updateinfo.py
+++ b/ompackagemanager/updateinfo.py
@@ -143,7 +143,7 @@ def new_libentry(libname: str,
                  entry,
                  hits: list[str],
                  repopath: str,
-                 omc: OMPython.OMCSessionZMQ) -> dict[str,str]:
+                 omc: OMPython.OMCSessionZMQ) -> dict[str, str]:
     """Create new entry for Modelica library.
 
     Args:
@@ -345,11 +345,12 @@ def main():
                                 hits += hitsNew
                         if len(hits) != 1:
                             print(str(len(hits)) + " hits for " + libname + " in " + tagName + ": " + str(hits))
-                            print("Check that " +
-                                  libname +
-                                  "/package.mo exists in tag: " +
-                                  tagName +
-                                  ". Maybe wrong spelling? If different naming than the repo add it to the 'names' for the lib in repos.json")
+                            print(
+                                "Check that " +
+                                libname +
+                                "/package.mo exists in tag: " +
+                                tagName +
+                                ". Maybe wrong spelling? If different naming than the repo add it to the 'names' for the lib in repos.json")
                             continue
                         omc.sendExpression("clear()")
                         if "standard" in entry:

--- a/ompackagemanager/updateinfo.py
+++ b/ompackagemanager/updateinfo.py
@@ -171,7 +171,11 @@ def new_libentry(libname: str,
         uses = [use for use in uses if use[0] != ignore]
 
     # Get conversions
-    (withoutConversion, withConversion) = omc.sendExpression("getConversionsFromVersions(%s)" % libname)
+    conversions = omc.sendExpression("getConversionsFromVersions(%s)" % libname)
+    if conversions is None:
+        withoutConversion, withConversion = [], []
+    else:
+        withoutConversion, withConversion = conversions
     withoutConversion = list(filter(None, [str(ver)
                              for ver in sorted([common.VersionNumber(v) for v in withoutConversion])]))
     withConversion = list(filter(None, [str(ver) for ver in sorted([common.VersionNumber(v) for v in withConversion])]))

--- a/rawdata.json
+++ b/rawdata.json
@@ -6878,7 +6878,7 @@
               "4.0.0",
               "4.1.0"
             ],
-            "version": "4.2.0-master"
+            "version": "4.2.0-dev"
           },
           "Modelica": {
             "convertFromVersion": [
@@ -6899,11 +6899,11 @@
               "Complex": "4.2.0-dev",
               "ModelicaServices": "4.2.0-dev"
             },
-            "version": "4.2.0-master"
+            "version": "4.2.0-dev"
           },
           "ModelicaReference": {
             "path": "ModelicaReference",
-            "version": "4.2.0-master"
+            "version": "4.2.0-dev"
           },
           "ModelicaServices": {
             "path": "ModelicaServices",
@@ -6917,28 +6917,28 @@
               "4.0.0",
               "4.1.0"
             ],
-            "version": "4.2.0-master"
+            "version": "4.2.0-dev"
           },
           "ModelicaTest": {
             "path": "ModelicaTest",
             "uses": {
               "Modelica": "4.2.0-dev"
             },
-            "version": "4.2.0-master"
+            "version": "4.2.0-dev"
           },
           "ModelicaTestOverdetermined": {
             "path": "ModelicaTestOverdetermined.mo",
             "uses": {
               "Modelica": "4.2.0-dev"
             },
-            "version": "4.2.0-master"
+            "version": "4.2.0-dev"
           },
           "ObsoleteModelica4": {
             "path": "ObsoleteModelica4.mo",
             "uses": {
               "Modelica": "4.2.0-dev"
             },
-            "version": "4.2.0-master"
+            "version": "4.2.0-dev"
           }
         },
         "sha": "0f27e460c7639c3e138766572f30842142367379"
@@ -6981,7 +6981,7 @@
           },
           "ModelicaReference": {
             "path": "ModelicaReference",
-            "version": "4.2.0-trunk"
+            "version": "4.2.0-dev"
           },
           "ModelicaServices": {
             "path": "ModelicaServices",
@@ -7012,14 +7012,14 @@
             "uses": {
               "Modelica": "4.2.0-dev"
             },
-            "version": "4.2.0-trunk"
+            "version": "4.2.0-dev"
           },
           "ObsoleteModelica4": {
             "path": "ObsoleteModelica4.mo",
             "uses": {
               "Modelica": "4.2.0-dev"
             },
-            "version": "4.2.0-trunk"
+            "version": "4.2.0-dev"
           }
         },
         "sha": "be25335e6d72e4ffab8c8cb70fb591aa703763bf"
@@ -8970,7 +8970,7 @@
             "uses": {
               "Modelica": "3.2.1"
             },
-            "version": "1.0.0-master"
+            "version": "1.0.0-Beta.1"
           }
         },
         "sha": "5fbae4513fa03d8937c27d4047670a146041c2d6"
@@ -9732,7 +9732,7 @@
               "Complex": "4.0.0",
               "Modelica": "4.0.0"
             },
-            "version": "3.1.0-master"
+            "version": "3.1.0-dev"
           }
         },
         "sha": "fe8aa5ceae90d123cc5b0f87be6362f6723cb116"
@@ -10974,7 +10974,7 @@
               "Complex": "4.0.0",
               "Modelica": "4.0.0"
             },
-            "version": "3.1.0-master"
+            "version": "3.1.0-alpha"
           }
         },
         "sha": "d4f7db61f1e179a2dd0388541d1ea8f26953fd5f"
@@ -11261,7 +11261,7 @@
             "uses": {
               "Modelica": "4.0.0"
             },
-            "version": "2.0.0-master"
+            "version": "2.0.0-dev"
           }
         },
         "sha": "22c7999846dd84964bbe174b3ec93d9c9a11d077"
@@ -13012,7 +13012,7 @@
             "uses": {
               "Modelica": "4.0.0"
             },
-            "version": "1.9.0-main"
+            "version": "1.9.0-ClaRa"
           }
         },
         "sha": "1845376fb70a32e51c8bbf75ae999c27662b376e"

--- a/tests/test_libentry.py
+++ b/tests/test_libentry.py
@@ -14,7 +14,7 @@ class TestNewLibentry(unittest.TestCase):
     def setUpClass(cls):
         """Clone git repositories, start OMC session."""
 
-        def checkout_repo(github_repo:str, refname:str) -> str:
+        def checkout_repo(github_repo: str, refname: str) -> str:
             """Clone and checkout a git repository from GitHub"""
             giturl = "https://github.com/%s.git" % github_repo
             repopath = os.path.join(cls.cache_dir, github_repo.split("/")[-1])
@@ -34,7 +34,6 @@ class TestNewLibentry(unittest.TestCase):
 
             return os.path.normpath(os.path.join(gitrepo.path, os.pardir))
 
-
         cls.cache_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tmp-cache")
         os.makedirs(cls.cache_dir, exist_ok=True)
 
@@ -48,7 +47,7 @@ class TestNewLibentry(unittest.TestCase):
     def tearDownClass(cls):
         """Remove git repositories, stop OMC session."""
         cls.omc.sendExpression("exit")
-        #shutil.rmtree(cls.cache_dir)
+        shutil.rmtree(cls.cache_dir)
 
     def tearDown(self):
         """Clear omc session"""
@@ -81,12 +80,12 @@ class TestNewLibentry(unittest.TestCase):
         self.omc.sendExpression('loadFile("%s", uses=false)' % hits[0])
 
         libentry = new_libentry(
-            libname = libname,
-            tagName = tagName,
-            entry = entry,
-            hits = hits,
-            repopath = repopath,
-            omc = self.omc
+            libname=libname,
+            tagName=tagName,
+            entry=entry,
+            hits=hits,
+            repopath=repopath,
+            omc=self.omc
         )
 
         expected_libentry = {
@@ -98,7 +97,7 @@ class TestNewLibentry(unittest.TestCase):
                 "SDF": "0.4.2"
             },
             "convertFromVersion": [
-              "2.1.0"
+                "2.1.0"
             ],
         }
         self.assertDictEqual(libentry, expected_libentry)
@@ -134,36 +133,37 @@ class TestNewLibentry(unittest.TestCase):
         self.omc.sendExpression('loadFile("%s", uses=false)' % hits[0])
 
         libentry = new_libentry(
-            libname = libname,
-            tagName = branch,
-            entry = entry,
-            hits = hits,
-            repopath = repopath,
-            omc = self.omc
+            libname=libname,
+            tagName=branch,
+            entry=entry,
+            hits=hits,
+            repopath=repopath,
+            omc=self.omc
         )
 
         expected_libentry = {
             "version": "4.2.0-dev",
             "path": "Modelica",
             "uses": {
-              "Complex": "4.2.0-dev",
-              "ModelicaServices": "4.2.0-dev"
+                "Complex": "4.2.0-dev",
+                "ModelicaServices": "4.2.0-dev"
             },
             "provides": [
-              "4.0.0",
-              "4.1.0"
+                "4.0.0",
+                "4.1.0"
             ],
             "convertFromVersion": [
-              "3.0.0",
-              "3.0.1",
-              "3.1.0",
-              "3.2.0",
-              "3.2.1",
-              "3.2.2",
-              "3.2.3"
+                "3.0.0",
+                "3.0.1",
+                "3.1.0",
+                "3.2.0",
+                "3.2.1",
+                "3.2.2",
+                "3.2.3"
             ]
         }
         self.assertDictEqual(libentry, expected_libentry)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_libentry.py
+++ b/tests/test_libentry.py
@@ -1,0 +1,169 @@
+import unittest
+import json
+import os
+from pathlib import Path
+import shutil
+import pygit2
+import OMPython
+
+from ompackagemanager.updateinfo import new_libentry, getgitrepo
+
+
+class TestNewLibentry(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Clone git repositories, start OMC session."""
+
+        def checkout_repo(github_repo:str, refname:str) -> str:
+            """Clone and checkout a git repository from GitHub"""
+            giturl = "https://github.com/%s.git" % github_repo
+            repopath = os.path.join(cls.cache_dir, github_repo.split("/")[-1])
+
+            if not os.path.exists(repopath):
+                pygit2.clone_repository(giturl, repopath)
+            gitrepo = pygit2.Repository(repopath)
+
+            if refname.startswith("refs/"):
+                gitrepo.checkout(
+                    gitrepo.lookup_reference(refname),
+                    strategy=pygit2.GIT_CHECKOUT_FORCE | pygit2.GIT_CHECKOUT_RECREATE_MISSING)
+            else:
+                gitrepo.checkout_tree(
+                    gitrepo.get(refname),
+                    strategy=pygit2.GIT_CHECKOUT_FORCE | pygit2.GIT_CHECKOUT_RECREATE_MISSING)
+
+            return os.path.normpath(os.path.join(gitrepo.path, os.pardir))
+
+
+        cls.cache_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tmp-cache")
+        os.makedirs(cls.cache_dir, exist_ok=True)
+
+        cls.omc = OMPython.OMCSessionZMQ()
+        cls.omc.sendExpression('setCommandLineOptions("--std=latest")')
+
+        cls.aixlib_path = checkout_repo("RWTH-EBC/AixLib", "refs/tags/v2.1.1")
+        cls.msl_path = checkout_repo("modelica/ModelicaStandardLibrary", "478538e43d3c9f682b2a6fb667783e2b3760f9f3")
+
+    @classmethod
+    def tearDownClass(cls):
+        """Remove git repositories, stop OMC session."""
+        cls.omc.sendExpression("exit")
+        #shutil.rmtree(cls.cache_dir)
+
+    def tearDown(self):
+        """Clear omc session"""
+        self.omc.sendExpression('clear()')
+
+    def test_aixlib_tag_version(self):
+        """Test libentry for AixLib v2.1.1"""
+
+        libname = "AixLib"
+        tagName = "v2.1.1"
+        entry = json.loads(
+            """
+            {
+                "names": ["AixLib"],
+                "github": "RWTH-EBC/AixLib",
+                "branches": {"development": "development", "main": "main"},
+                "ignore-tags": ["v0.7.2", "v0.7.1", "v0.7.0", "v0.1.0"],
+                "support": [
+                ["prerelease", "noSupport"],
+                [">=1.3.1", "support"],
+                [">=0.9.1", "experimental"],
+                ["*", "obsolete"]
+                ]
+            }
+            """)
+
+        # Load package.mo
+        repopath = self.aixlib_path
+        hits = [os.path.join(repopath, "AixLib", "package.mo")]
+        self.omc.sendExpression('loadFile("%s", uses=false)' % hits[0])
+
+        libentry = new_libentry(
+            libname = libname,
+            tagName = tagName,
+            entry = entry,
+            hits = hits,
+            repopath = repopath,
+            omc = self.omc
+        )
+
+        expected_libentry = {
+            "version": "2.1.1",
+            "path": "AixLib",
+            "uses": {
+                "Modelica": "4.0.0",
+                "Modelica_DeviceDrivers": "2.1.1",
+                "SDF": "0.4.2"
+            },
+            "convertFromVersion": [
+              "2.1.0"
+            ],
+        }
+        self.assertDictEqual(libentry, expected_libentry)
+
+    def test_modelica_master_version(self):
+        """Test libentry for Modelica master"""
+
+        libname = "Modelica"
+        branch = "master"
+        entry = json.loads(
+            """
+            {
+                "names": ["Modelica","ModelicaReference","ModelicaServices","ModelicaTest","ModelicaTestOverdetermined","Complex","ObsoleteModelica3","ObsoleteModelica4"],
+                "github": "modelica/ModelicaStandardLibrary",
+                "branches": {
+                    "master": "master"
+                },
+                "standard": [
+                    [">=3.4.0", "latest"],
+                    ["*", "latest"]
+                ],
+                "support": [
+                    [">=3.2.3", "fullSupport"],
+                    ["*", "obsolete"]
+                ]
+            }
+            """)
+
+        # Load package.mo
+        repopath = self.msl_path
+        hits = [os.path.join(repopath, "Modelica", "package.mo")]
+        self.omc.sendExpression('clear()')
+        self.omc.sendExpression('loadFile("%s", uses=false)' % hits[0])
+
+        libentry = new_libentry(
+            libname = libname,
+            tagName = branch,
+            entry = entry,
+            hits = hits,
+            repopath = repopath,
+            omc = self.omc
+        )
+
+        expected_libentry = {
+            "version": "4.2.0-dev",
+            "path": "Modelica",
+            "uses": {
+              "Complex": "4.2.0-dev",
+              "ModelicaServices": "4.2.0-dev"
+            },
+            "provides": [
+              "4.0.0",
+              "4.1.0"
+            ],
+            "convertFromVersion": [
+              "3.0.0",
+              "3.0.1",
+              "3.1.0",
+              "3.2.0",
+              "3.2.1",
+              "3.2.2",
+              "3.2.3"
+            ]
+        }
+        self.assertDictEqual(libentry, expected_libentry)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_normalize_version.py
+++ b/tests/test_normalize_version.py
@@ -3,6 +3,7 @@ from ompackagemanager.updateinfo import normalize_version
 
 
 class TestVersionNormalization(unittest.TestCase):
+    """Test function normalize_version"""
 
     def test_master_dev_version(self):
         """Test version on master branch"""
@@ -10,20 +11,26 @@ class TestVersionNormalization(unittest.TestCase):
         tagName = "master"
         entry = dict()
 
-        normalized_version = normalize_version(
-            version=version, tagName=tagName, entry=entry)
+        normalized_version = normalize_version(version=version, tagName=tagName, entry=entry)
         self.assertEqual(normalized_version, "1.2.3-master")
 
-    @unittest.expectedFailure
     def test_master_w_build_dev_version(self):
         """Test version with build on master branch"""
         version = "1.2.3 build"
         tagName = "master"
         entry = dict()
 
-        normalized_version = normalize_version(
-            version=version, tagName=tagName, entry=entry)
+        normalized_version = normalize_version(version=version, tagName=tagName, entry=entry)
         self.assertEqual(normalized_version, "1.2.3-build")
+
+    def test_master_w_prerelease_dev_version(self):
+        """Test version with prerelease on master branch"""
+        version = "1.2.3-prerelease"
+        tagName = "master"
+        entry = dict()
+
+        normalized_version = normalize_version(version=version, tagName=tagName, entry=entry)
+        self.assertEqual(normalized_version, "1.2.3-prerelease")
 
     def test_empty_tag(self):
         """Test version with build without tag name"""
@@ -31,8 +38,7 @@ class TestVersionNormalization(unittest.TestCase):
         tagName = ""
         entry = dict()
 
-        normalized_version = normalize_version(
-            version=version, tagName=tagName, entry=entry)
+        normalized_version = normalize_version(version=version, tagName=tagName, entry=entry)
         self.assertEqual(normalized_version, "1.2.3-build")
 
 


### PR DESCRIPTION
## Issue

Should fix https://github.com/OpenModelica/OpenModelicaLibraryTesting/issues/222.

## Changes

  - No longer override prerelease of semver version if on master/main/trunk branch
  - Fixes missing version v4.2.0-dev from MSL from OMPackageManager
  - Adding tests for `new_libentry`