### PR TITLE
ThermoSysPro moved to gitlab.pam-retd.fr

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -1451,7 +1451,7 @@
   },
   "ThermoSysPro": {
     "names": ["ThermoSysPro"],
-    "github": "ThermoSysPro/ThermoSysPro",
+    "git": "https://gitlab.pam-retd.fr/thermosysproandco/ThermoSysPro.git",
     "branches": {"master": "master"},
     "support": [
       ["prerelease", "noSupport"],


### PR DESCRIPTION
## Changes
  
  - GitHub repo name changed to git adress: `https://gitlab.pam-retd.fr/thermosysproandco/ThermoSysPro`