### PR TITLE
LEPSE repo changed structure

### DIFF
--- a/rawdata.json
+++ b/rawdata.json
@@ -3895,7 +3895,7 @@
             "version": "1.8.0-nightly"
           }
         },
-        "sha": "7197f2ca333ed0e981519d48ce2cd99828476d31"
+        "sha": "d39d885af4f9fa25b3a1b615c27efbda9e4aa553"
       },
       "nightly-release": {
         "libs": {
@@ -6483,7 +6483,19 @@
   },
   "LEPSE": {
     "refs": {
-      "v1.2": {
+      "main": {
+        "libs": {
+          "LEPSE": {
+            "path": "LEPSE",
+            "uses": {
+              "Modelica": "4.0.0"
+            },
+            "version": "main"
+          }
+        },
+        "sha": "c408ed518f93affb1af77b6203c22ca343263763"
+      },
+      "v1.2.0": {
         "libs": {
           "LEPSE": {
             "path": "LEPSE",
@@ -7882,7 +7894,7 @@
             "version": "3.2.1-main"
           }
         },
-        "sha": "f1902539cc050242392441581a1520d6901ffe01"
+        "sha": "2c93b51401432b88ec6e3d24fd0a4c682c6c75e5"
       },
       "v1.0.0": {
         "libs": {

--- a/repos.json
+++ b/repos.json
@@ -707,10 +707,11 @@
   },
   "LEPSE": {
     "branches": {
-      "v1.2": "v1.2"
+      "main": "main"
     },
     "names": ["LEPSE"],
     "github": "AndrejFlorinskii/LEPSE",
+    "ignore-tags": ["v1.1.0"],
     "support": [
       ["prerelease", "noSupport"],
       ["*", "experimental"]


### PR DESCRIPTION
Related to https://github.com/OpenModelica/OMPackageManager/issues/57.
Exclude tag `v1.1.0`.

Fixes broken update in Jenkins:

```bash
python3 -m ompackagemanager genindex

Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/var/lib/jenkins/ws/Update Package Index/ompackagemanager/__main__.py", line 67, in <module>
    main()
  File "/var/lib/jenkins/ws/Update Package Index/ompackagemanager/__main__.py", line 63, in main
    args.func()
  File "/var/lib/jenkins/ws/Update Package Index/ompackagemanager/genindex.py", line 127, in main
    raise Exception(firstKey + " " + refKey)

Exception: LEPSE v1.1.0

script returned exit code 1
```