### PR TITLE
Exclude broken version for LEPSE

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -711,7 +711,7 @@
     },
     "names": ["LEPSE"],
     "github": "AndrejFlorinskii/LEPSE",
-    "ignore-tags": ["v1.1.0"],
+    "ignore-tags": ["v1.1.0", "v1.2.1"],
     "support": [
       ["prerelease", "noSupport"],
       ["*", "experimental"]


### PR DESCRIPTION
Fixes 

```bash
python3 -m ompackagemanager genindex
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/var/lib/jenkins/ws/Update Package Index/ompackagemanager/__main__.py", line 67, in <module>
    main()
  File "/var/lib/jenkins/ws/Update Package Index/ompackagemanager/__main__.py", line 63, in main
    args.func()
  File "/var/lib/jenkins/ws/Update Package Index/ompackagemanager/genindex.py", line 127, in main
    raise Exception(firstKey + " " + refKey)
Exception: LEPSE v1.2.1
```