### PR TITLE
Changing ModPowerSystems git location

### DIFF
--- a/rawdata.json
+++ b/rawdata.json
@@ -6708,24 +6708,6 @@
       }
     }
   },
-  "ModPowerSystems": {
-    "refs": {
-      "master": {
-        "libs": {
-          "ModPowerSystems": {
-            "path": "ModPowerSystems",
-            "uses": {
-              "Complex": "3.2.2",
-              "Modelica": "3.2.2",
-              "ModelicaServices": "3.2.2"
-            },
-            "version": "master"
-          }
-        },
-        "sha": "df3afce27d5e935c4111f392275744a655abe216"
-      }
-    }
-  },
   "ModelManagement": {
     "refs": {
       "master": {

--- a/repos.json
+++ b/repos.json
@@ -939,15 +939,6 @@
       ["*", "obsolete"]
     ]
   },
-  "ModPowerSystems": {
-    "names": ["ModPowerSystems"],
-    "github": "ModPowerSystems/ModPowerSystems",
-    "branches": {"master": "master"},
-    "support": [
-      ["prerelease", "noSupport"],
-      ["*", "experimental"]
-    ]
-  },
   "MultiPhaseMixtureMedia": {
     "names": ["MultiPhaseMixture"],
     "github": "jwindahlModelon/MultiPhaseMixtureMedia",


### PR DESCRIPTION
ModPowerSystems/ModPowerSystems was removed from GitHub or changed to be private.
The GitHub organistaion [ModPowerSystems ](https://github.com/ModPowerSystems) doesn't list any repositories any more.

Acording to https://www.fein-aachen.org/projects/modpowersystems/ there is a [GitLab repo](https://git.rwth-aachen.de/acs/public/simulation/modpowersystems). Switching to that one, containing the same commit / SHA.