### PR TITLE
Add OpenIWPI library to repos.json

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -1074,6 +1074,16 @@
       ["*", "obsolete"]
     ]
   },
+  "OpenIWPI": {
+    "names": ["OpenIWPI"],
+    "github": "ALSETLab/OpenIWPI",
+    "branches": {"main": "main"},
+    "support": [
+      ["prerelease", "noSupport"],
+      [">=1.0.0", "experimental"],
+      ["*", "obsolete"]
+    ]
+  },
   "OpenModelica_Microgrids": {
     "names": ["OpenModelica_Microgrids"],
     "github": "upb-lea/OpenModelica_Microgrids",


### PR DESCRIPTION
**OpenIWPI** (Open-Instance Wave-Phasor Interface Library) is a Modelica library that interconnects electromagnetic-transient (EMT) models with the phasor-based power-system components of OpenIPSL, enabling hybrid EMT–TS simulation and small-signal linearization in a single Modelica model — without co-simulation.

- Repository: https://github.com/ALSETLab/OpenIWPI
- License: BSD-3-Clause
- Current release: v1.0.0
- Companion paper: M. de Castro and L. Vanfretti, "OpenIWPI: Open-Instance Wave-Phasor Interface Library for Power System Simulation Studies in Modelica," 16th International Modelica & FMI Conference, Lucerne, September 2025.
- Zenodo DOI: https://doi.org/10.5281/zenodo.20586745

Support level set to `experimental` (tested with Dymola 2025x; the SimpleCircuit example also simulates correctly in OpenModelica, though loading produces annotation-related scripting warnings about unresolved `enable=` variables in dialog annotations — these do not affect simulation).