### PR TITLE
Add MMChvdcLibrary to repos.json

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -777,6 +777,16 @@
       ["*", "obsolete"]
     ]
   },
+  "MMChvdcLibrary": {
+    "names": ["MMChvdcLibrary"],
+    "github": "ALSETLab/MMChvdcLibrary",
+    "branches": {"main": "main"},
+    "support": [
+      ["prerelease", "noSupport"],
+      [">=1.0.0", "experimental"],
+      ["*", "obsolete"]
+    ]
+  },
   "Modelica": {
     "names": ["Modelica","ModelicaReference","ModelicaServices","ModelicaTest","ModelicaTestOverdetermined","Complex","ObsoleteModelica3","ObsoleteModelica4"],
     "github": "OpenModelica/OpenModelica-ModelicaStandardLibrary",


### PR DESCRIPTION
**MMChvdcLibrary** is a Modelica library for phasor-domain arm average value modeling of MMC-based HVDC systems, designed to be easily combined with OpenIPSL for power system simulation. It provides modular converter models, control blocks, sensors, and mathematical operators, assembled into station-level models supporting P-Q, Vdc–Q, and Vac phasor control modes.

- Repository: https://github.com/ALSETLab/MMChvdcLibrary
- License: BSD-3-Clause
- Current release: v1.0.0-alpha
- Zenodo DOI: https://doi.org/10.5281/zenodo.20186636
- Reference publication: Md N.H. Chowdhury and L. Vanfretti, "MMChvdcLibrary: Modeling Arm Average Value Modular Multilevel Converters in Modelica for Power System Simulation," American Modelica & FMI Conference 2026, Atlanta, GA, USA, October 12–14, 2026.

Support level set to `experimental` (developed and tested with Dymola 2026 Refresh 1; all three bundled examples also run correctly in OpenModelica v1.26.3).